### PR TITLE
Prevent no-op board commands from altering undo history

### DIFF
--- a/core/src/main/java/com/darren/sudokuscope/core/GameState.java
+++ b/core/src/main/java/com/darren/sudokuscope/core/GameState.java
@@ -37,11 +37,16 @@ public final class GameState {
   public BoardEvent apply(BoardCommand command) {
     Objects.requireNonNull(command, "command");
     BoardCommand.MutationResult result = command.apply(board);
-    board = result.newBoard();
+    SudokuBoard newBoard = result.newBoard();
+    BoardEvent event = result.event();
+    if (event.isNoOp() || newBoard.equals(board)) {
+      return event;
+    }
+    board = newBoard;
     undoStack.push(result.undoCommand());
     redoStack.clear();
-    notifyObservers(result.event());
-    return result.event();
+    notifyObservers(event);
+    return event;
   }
 
   public boolean canUndo() {

--- a/core/src/test/java/com/darren/sudokuscope/core/GameStateTest.java
+++ b/core/src/test/java/com/darren/sudokuscope/core/GameStateTest.java
@@ -21,4 +21,30 @@ class GameStateTest {
     state.redo();
     assertThat(state.board().valueAt(1, 1)).isEqualTo(9);
   }
+
+  @Test
+  void noOpCommandsDoNotModifyHistory() {
+    GameState state = new GameState();
+    CellPosition position = new CellPosition(0, 0);
+
+    BoardEvent initialEvent = state.apply(new SetValueCommand(position, 0));
+    assertThat(initialEvent.isNoOp()).isTrue();
+    assertThat(state.canUndo()).isFalse();
+
+    state.apply(new SetValueCommand(position, 5));
+    assertThat(state.board().valueAt(0, 0)).isEqualTo(5);
+    assertThat(state.canUndo()).isTrue();
+
+    state.apply(new SetValueCommand(position, 5));
+    assertThat(state.canUndo()).isTrue();
+
+    state.undo();
+    assertThat(state.board().valueAt(0, 0)).isZero();
+    assertThat(state.canUndo()).isFalse();
+    assertThat(state.canRedo()).isTrue();
+
+    state.apply(new SetValueCommand(position, 0));
+    assertThat(state.canUndo()).isFalse();
+    assertThat(state.canRedo()).isTrue();
+  }
 }


### PR DESCRIPTION
## Summary
- avoid recording undo history entries when a board command results in no change
- add a regression test covering the undo/redo stacks when no-op commands are applied

## Testing
- `sh gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68e441151190832fa5027b9f7be5b49a